### PR TITLE
Fix Import Fehler

### DIFF
--- a/cfximport.php
+++ b/cfximport.php
@@ -888,6 +888,8 @@
                 elseif( preg_match('/.*<(.+)>$/', $addr, $addr_matches) === 1 ){
                   $addr = $addr_matches[1];
                 }
+                # Confixx erlaubt nicht standard-konforme Zeichen wie z.B. Leerzeichen und Tabulatoren, filtere diese
+                $addr = filter_var($addr, FILTER_SANITIZE_EMAIL);
                 # Confixx erlaubt scheinbar doppelte Ziele. LC nicht. Also entferne Duplikate:
                 if( ! in_array($addr, $dest) ){
                   array_push($dest, $addr);
@@ -1362,6 +1364,8 @@
 
     # Kontakt anlegen:
     $contact_data = _setContactAddData($custdata);
+    # Confixx erlaubt nicht standard-konforme Zeichen wie z.B. Leerzeichen und Tabulatoren, filtere diese
+    $contact_data['email'] = filter_var($contact_data['email'], FILTER_SANITIZE_EMAIL);
     try {
       $contact_data['auth'] = createToken('ContactAdd', $cust_id);
       $response = $client->ContactAdd($contact_data);

--- a/cfximport.php
+++ b/cfximport.php
@@ -884,7 +884,14 @@
                   # lokales Postfach: Standard-Domain anfügen
                   $addr .= '@' . $stddomain;
                 }
-                array_push($dest, $addr);
+                # Confixx erlaubt Weiterleitungsziele im Format "Name <name@example.com>", LC nicht
+                elseif( preg_match('/.*<(.+)>$/', $addr, $addr_matches) === 1 ){
+                  $addr = $addr_matches[1];
+                }
+                # Confixx erlaubt scheinbar doppelte Ziele. LC nicht. Also entferne Duplikate:
+                if( ! in_array($addr, $dest) ){
+                  array_push($dest, $addr);
+                }
               }
               mysql_free_result($res2);
               if (count($dest) == 0) continue;


### PR DESCRIPTION
Behebt Problematische Confixx-Einträge, die sonst zu Import-Fehlern führen:

* Doppelte Weiterleitungsziele
* Weiterleitungsziele im Format `Name <name@example.com>`
* Kontakt E-Mail-Adresse mit führenden oder nachfolgenden Leerzeichen
* E-Mail Adressen mit nicht standardisierten Zeichen (via filter_var und FILTER_SANITIZE_EMAIL)