### PR TITLE
Behebe PHP Notice beim Anlegen von Vertraegen

### DIFF
--- a/cfximport.php
+++ b/cfximport.php
@@ -617,7 +617,7 @@
             $hostingpaket['webstats'] = 2;    # AWStats einrichten
           }
 
-          if( $hostingpaket['php'] > 0 ) {
+          if( isset($hostingpaket['php']) AND $hostingpaket['php'] > 0 ) {
             $hostingpaket['php'] = $OPTS['php'];
           }
           $hostingpaket['auth'] = createToken('HostingSubscriptionAdd', $rcustomer_id);


### PR DESCRIPTION
Key php in $hostingpaket ist offensichtlich unset wenn PHP durch Angebot festgelegt wird
und die Einstellung des Vertrags nicht abweicht.