### PR TITLE
avoid PHP Notice when checking for "--permissive" parameter

### DIFF
--- a/cfximport.php
+++ b/cfximport.php
@@ -1500,7 +1500,7 @@
                         'email'      => $contact['emailadresse'],
                        );
 
-    if ($OPTS['permissive']) $contactdata['permissive'] = true;
+    if (isset($OPTS['permissive']) && $OPTS['permissive']) $contactdata['permissive'] = true;
 
     return($contactdata);
   } 


### PR DESCRIPTION
don't check for an uninitialized parameter